### PR TITLE
Extract (overridable) helpers for the locale picker

### DIFF
--- a/app/helpers/blacklight/locale_picker/locale_helper.rb
+++ b/app/helpers/blacklight/locale_picker/locale_helper.rb
@@ -1,0 +1,30 @@
+# Helpers for building the locale picker
+module Blacklight::LocalePicker::LocaleHelper
+  # Locales to display in the locale picker; by default, it picks up
+  # the information from the engine configuration
+  def available_locales
+    Blacklight::LocalePicker::Engine.config.available_locales
+  end
+
+  # Returns the url for the current page in the new locale. This may be
+  # overridden in downstream applications where our naive use of `url_for`
+  # is insufficient to generate the expected routes
+  def current_page_for_locale(locale)
+    initial_exception = nil
+
+    ([self] + additional_locale_routing_scopes).each do |scope|
+      return scope.public_send(:url_for, locale: locale)
+    rescue ActionController::UrlGenerationError => e
+      initial_exception ||= e
+    end
+
+    raise initial_exception
+  end
+
+  # Returns an array of routing scopes (e.g. mounted engines) to attempt to use
+  # for switching locale-specific routes. This is likely overridden in complex
+  # applications to add scopes for additional mounted engines
+  def additional_locale_routing_scopes
+    [blacklight]
+  end
+end

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,4 +1,4 @@
-<% if Blacklight::LocalePicker::Engine.config.available_locales.many?  %>
+<% if available_locales.many?  %>
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu">
       <span class="sr-only"><%= t('blacklight.toolbar.language_switch') %></span>
@@ -8,9 +8,9 @@
     <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
       <li role="presentation" class="dropdown-header"><%= t('blacklight.toolbar.language_switch') %></li>
       <li role="presentation" class="divider"></li>
-      <% Blacklight::LocalePicker::Engine.config.available_locales.each do |language| %>
-        <li role="presentation" lang="<%= language %>">
-          <%= link_to t("locales.#{language}"), (url_for(locale: language) rescue blacklight.url_for(locale: language)), class: 'dropdown-item' %>
+      <% available_locales.each do |locale| %>
+        <li role="presentation" lang="<%= locale %>">
+          <%= link_to t("locales.#{locale}"), current_page_for_locale(locale), class: 'dropdown-item' %>
         </li>
       <% end %>
     </ul>

--- a/lib/generators/blacklight/locale_picker/install_generator.rb
+++ b/lib/generators/blacklight/locale_picker/install_generator.rb
@@ -13,5 +13,11 @@ module Blacklight::LocalePicker
         "\n  include Blacklight::LocalePicker::Concern"
       end
     end
+
+    def add_locale_picker_helpers
+      inject_into_file 'app/helpers/application_helper.rb', after: 'module ApplicationHelper' do
+        "\n  include Blacklight::LocalePicker::LocaleHelper"
+      end
+    end
   end
 end


### PR DESCRIPTION
This should allow downstream applications (e.g. those using arclight or spotlight) to include the routes from those mounted engines with minimal effort; hopefully by doing something like:

```ruby
module ApplicationHelper
  include Blacklight::LocalePicker::LocaleHelper

  def additional_locale_routing_scopes
    [blacklight, arclight_engine]
  end
end
```
