### PR TITLE
Specify that this gem requires ruby 2.5 or greater

### DIFF
--- a/blacklight-locale_picker.gemspec
+++ b/blacklight-locale_picker.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary     = ""
   spec.description = ""
   spec.license     = "Apache-2.0"
-
+  
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.5.0' 
   spec.add_dependency "rails", "~> 5.2.3"
 
   spec.add_development_dependency "capybara"


### PR DESCRIPTION
Due to the use of a `rescue` in a block.  https://blog.bigbinary.com/2017/10/24/ruby-2.5-allows-rescue-inside-do-end-blocks.html

https://github.com/projectblacklight/blacklight-locale_picker/blob/aa6697e931af11a4e201750cd02d4c790532a635/app/helpers/blacklight/locale_picker/locale_helper.rb#L15-L19