### PR TITLE
Use languages' native spellings instead of English names 

### DIFF
--- a/config/locales/locale_picker.de.yml
+++ b/config/locales/locale_picker.de.yml
@@ -1,0 +1,12 @@
+de:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.en.yml
+++ b/config/locales/locale_picker.en.yml
@@ -1,12 +1,12 @@
 en:
   locales:
-    de: German
+    de: Deutsch
     en: English
-    es: Spanish
-    fr: French
-    hu: Hungarian
-    it: Italian
-    nl: Dutch
-    pt-BR: Portuguese - Brazil
-    sq: Albanian
-    zh: Chinese
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.es.yml
+++ b/config/locales/locale_picker.es.yml
@@ -1,0 +1,12 @@
+es:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.fr.yml
+++ b/config/locales/locale_picker.fr.yml
@@ -1,0 +1,12 @@
+fr:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.hu.yml
+++ b/config/locales/locale_picker.hu.yml
@@ -1,0 +1,12 @@
+hu:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.it.yml
+++ b/config/locales/locale_picker.it.yml
@@ -1,0 +1,12 @@
+it:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.nl.yml
+++ b/config/locales/locale_picker.nl.yml
@@ -1,0 +1,12 @@
+nl:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.pt-BR.yml
+++ b/config/locales/locale_picker.pt-BR.yml
@@ -1,0 +1,12 @@
+pt-BR:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.sq.yml
+++ b/config/locales/locale_picker.sq.yml
@@ -1,0 +1,12 @@
+sq:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/config/locales/locale_picker.zh.yml
+++ b/config/locales/locale_picker.zh.yml
@@ -1,0 +1,12 @@
+zh:
+  locales:
+    de: Deutsch
+    en: English
+    es: Español
+    fr: Français
+    hu: Magyar
+    it: Italiano
+    nl: Nederlands
+    pt-BR: Português braileiro
+    sq: Shqip
+    zh: 中文

--- a/spec/features/locale_picker_spec.rb
+++ b/spec/features/locale_picker_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe 'Locale picker', type: :feature do
 
     expect(page).to have_css '#language-dropdown-menu'
     expect(page).to have_css 'li', text: 'English'
-    expect(page).to have_css 'li', text: 'Spanish'
+    expect(page).to have_css 'li', text: 'Español'
 
     expect(page).to have_text 'Welcome'
-    click_link 'Spanish'
+    click_link 'Español'
     expect(page).to have_text 'Bienvenido'
 
     click_link 'Entrar'
     expect(page).to have_text 'Historia'
+    expect(page).to have_css 'li', text: 'English'
   end
 end


### PR DESCRIPTION
Closes #3
Choosing this approach per @ggeisler's design in [projectblacklight/arclight#544](https://github.com/projectblacklight/arclight/issues/544#issuecomment-514347302). This approach also helps us minimize the number of translations to manage (i.e. 10 native language spellings vs. 10 languages * 10 translations = 100 translations). 

## Before
![english language names](https://user-images.githubusercontent.com/5402927/63465482-33dda880-c416-11e9-972e-eae953f2d664.png)
![spanish with keys](https://user-images.githubusercontent.com/5402927/63465486-36d89900-c416-11e9-8613-3a3e204b10d2.png)

## After
![english selected, native language spellings](https://user-images.githubusercontent.com/5402927/63465517-4657e200-c416-11e9-83b2-936b1474ec47.png)
![spanish selected, native language spellings](https://user-images.githubusercontent.com/5402927/63465519-4657e200-c416-11e9-8869-4fde6bf54449.png)

You'll also notice that I've provided the list of native languages per locale. This COULD be DRY-er by choosing a default fallback language. The approach I've selected doesn't make assumptions about an application's default language. 