### PR TITLE
Install i18n-tasks gem; add translations health check to default rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ To add locales to your application, add an initializer.
 ```
 Blacklight::LocalePicker::Engine.config.available_locales = [:en, :es]
 ```
+
+## Translations
+`blacklight-locale_picker` ships with i18n-tasks to help manage translations. To run a translation health check, run:
+```
+$ bundle exec rake i18n:health
+```

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,13 @@ RSpec::Core::RakeTask.new(:spec)
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
+namespace :i18n do
+  desc 'Check for missing translations'
+  task :health do
+    system 'bundle exec i18n-tasks health'
+  end
+end
+
 require 'engine_cart/rake_task'
 
 task ci: ['engine_cart:generate'] do
@@ -43,4 +50,4 @@ task ci: ['engine_cart:generate'] do
   end
 end
 
-task default: :ci
+task default: %i[i18n:health ci]

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,12 +1,10 @@
 <% if available_locales.many?  %>
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu">
-      <span class="sr-only"><%= t('blacklight.toolbar.language_switch') %></span>
       <span><%= t("locales.#{I18n.locale}") %></span>
       <b class="caret"></b>
     </a>
     <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
-      <li role="presentation" class="dropdown-header"><%= t('blacklight.toolbar.language_switch') %></li>
       <li role="presentation" class="divider"></li>
       <% available_locales.each do |locale| %>
         <li role="presentation" lang="<%= locale %>">

--- a/blacklight-locale_picker.gemspec
+++ b/blacklight-locale_picker.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "solr_wrapper"
+  spec.add_development_dependency "i18n-tasks"
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,134 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+# base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+locales: [de, en, es, fr, hu, it, nl, pt-BR, sq, zh]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+    - config/locales/locale_picker.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/locale_picker.de.yml
+++ b/config/locales/locale_picker.de.yml
@@ -1,3 +1,4 @@
+---
 de:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.en.yml
+++ b/config/locales/locale_picker.en.yml
@@ -1,3 +1,4 @@
+---
 en:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.es.yml
+++ b/config/locales/locale_picker.es.yml
@@ -1,3 +1,4 @@
+---
 es:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.fr.yml
+++ b/config/locales/locale_picker.fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.hu.yml
+++ b/config/locales/locale_picker.hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.it.yml
+++ b/config/locales/locale_picker.it.yml
@@ -1,3 +1,4 @@
+---
 it:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.nl.yml
+++ b/config/locales/locale_picker.nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.pt-BR.yml
+++ b/config/locales/locale_picker.pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.sq.yml
+++ b/config/locales/locale_picker.sq.yml
@@ -1,3 +1,4 @@
+---
 sq:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.zh.yml
+++ b/config/locales/locale_picker.zh.yml
@@ -1,3 +1,4 @@
+---
 zh:
   locales:
     de: Deutsch

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'i18n/tasks'
+RSpec.describe 'I18n' do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:unused_keys) { i18n.unused_keys }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+    "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  it 'does not have unused keys' do
+    expect(unused_keys).to be_empty,
+    "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused'"
+  end
+
+  it 'files are normalized' do
+    non_normalized = i18n.non_normalized_paths
+    error_message = "The following files need to be normalized:\n" \
+                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                    'Please run `i18n-tasks normalize` to fix'
+    expect(non_normalized).to be_empty, error_message
+  end
+end


### PR DESCRIPTION
Closes #4

This PR adds the `i18n-tasks` gem as a dev dependency and then does a couple of things to make `i18n-tasks health` happy:
- `missing`: remove language switch header (both visible and screenreader only) in favor of approach in #7 
- adds `i18n-tasks health` to the default rake task
- adds specs that will fail if project is has any keys that are missing, unused, or locales that have not been normalized. This is a fairly small project so I'm hoping this isn't too strict! 
- adds some info to the README, but more documentation re: adding a new language (both in the gem and in a downstream application) will happen in another PR
