### PR TITLE
Update screenreader approach; fix generator for locales with country codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ rails generate blacklight:locale_picker:install
 ## Configuration
 To add locales to your application, add an initializer.
 ```
-Blacklight::LocalePicker::Engine.config.available_locales = [:en, :es]
+Blacklight::LocalePicker::Engine.config.available_locales = ['en', 'es', 'pt-BR']
 ```
 
 ## Translations

--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ To add locales to your application, add an initializer.
 ```
 Blacklight::LocalePicker::Engine.config.available_locales = [:en, :es]
 ```
+
+## Translations
+`blacklight-locale_picker` ships with i18n-tasks to help manage translations. To run a translation health check, run:
+```
+$ bundle exec rake i18n:health
+```

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,13 @@ RSpec::Core::RakeTask.new(:spec)
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
+namespace :i18n do
+  desc 'Check for missing translations'
+  task :health do
+    system 'bundle exec i18n-tasks health'
+  end
+end
+
 require 'engine_cart/rake_task'
 
 task ci: ['engine_cart:generate'] do
@@ -43,4 +50,4 @@ task ci: ['engine_cart:generate'] do
   end
 end
 
-task default: :ci
+task default: %i[i18n:health ci]

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,12 +1,10 @@
 <% if available_locales.many?  %>
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu">
-      <span class="sr-only"><%= t('blacklight.toolbar.language_switch') %></span>
       <span><%= t("locales.#{I18n.locale}") %></span>
       <b class="caret"></b>
     </a>
     <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
-      <li role="presentation" class="dropdown-header"><%= t('blacklight.toolbar.language_switch') %></li>
       <li role="presentation" class="divider"></li>
       <% available_locales.each do |locale| %>
         <li role="presentation" lang="<%= locale %>">

--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -1,6 +1,6 @@
 <% if available_locales.many?  %>
   <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu">
+    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="language-dropdown-menu" aria-label="<%= t('blacklight.header_links.locale_switcher') %>">
       <span><%= t("locales.#{I18n.locale}") %></span>
       <b class="caret"></b>
     </a>

--- a/blacklight-locale_picker.gemspec
+++ b/blacklight-locale_picker.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "solr_wrapper"
+  spec.add_development_dependency "i18n-tasks"
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,134 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+# base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+locales: [de, en, es, fr, hu, it, nl, pt-BR, sq, zh]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+    - config/locales/locale_picker.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/locale_picker.de.yml
+++ b/config/locales/locale_picker.de.yml
@@ -1,3 +1,4 @@
+---
 de:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.de.yml
+++ b/config/locales/locale_picker.de.yml
@@ -1,5 +1,8 @@
 ---
 de:
+  blacklight:
+    header_links:
+      locale_switcher: Sprache
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.en.yml
+++ b/config/locales/locale_picker.en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  blacklight:
+    header_links:
+      locale_switcher: Language
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.en.yml
+++ b/config/locales/locale_picker.en.yml
@@ -1,3 +1,4 @@
+---
 en:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.es.yml
+++ b/config/locales/locale_picker.es.yml
@@ -1,5 +1,8 @@
 ---
 es:
+  blacklight:
+    header_links:
+      locale_switcher: Idioma
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.es.yml
+++ b/config/locales/locale_picker.es.yml
@@ -1,3 +1,4 @@
+---
 es:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.fr.yml
+++ b/config/locales/locale_picker.fr.yml
@@ -1,5 +1,8 @@
 ---
 fr:
+  blacklight:
+    header_links:
+      locale_switcher: Langue
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.fr.yml
+++ b/config/locales/locale_picker.fr.yml
@@ -1,3 +1,4 @@
+---
 fr:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.hu.yml
+++ b/config/locales/locale_picker.hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.hu.yml
+++ b/config/locales/locale_picker.hu.yml
@@ -1,5 +1,8 @@
 ---
 hu:
+  blacklight:
+    header_links:
+      locale_switcher: Nyelv
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.it.yml
+++ b/config/locales/locale_picker.it.yml
@@ -1,3 +1,4 @@
+---
 it:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.it.yml
+++ b/config/locales/locale_picker.it.yml
@@ -1,5 +1,8 @@
 ---
 it:
+  blacklight:
+    header_links:
+      locale_switcher: Lingua
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.nl.yml
+++ b/config/locales/locale_picker.nl.yml
@@ -1,5 +1,8 @@
 ---
 nl:
+  blacklight:
+    header_links:
+      locale_switcher: Taal
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.nl.yml
+++ b/config/locales/locale_picker.nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.pt-BR.yml
+++ b/config/locales/locale_picker.pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.pt-BR.yml
+++ b/config/locales/locale_picker.pt-BR.yml
@@ -1,5 +1,8 @@
 ---
 pt-BR:
+  blacklight:
+    header_links:
+      locale_switcher: Idioma
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.sq.yml
+++ b/config/locales/locale_picker.sq.yml
@@ -1,3 +1,4 @@
+---
 sq:
   locales:
     de: Deutsch

--- a/config/locales/locale_picker.sq.yml
+++ b/config/locales/locale_picker.sq.yml
@@ -1,5 +1,8 @@
 ---
 sq:
+  blacklight:
+    header_links:
+      locale_switcher: Gjuhë
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.zh.yml
+++ b/config/locales/locale_picker.zh.yml
@@ -1,5 +1,8 @@
 ---
 zh:
+  blacklight:
+    header_links:
+      locale_switcher: 语言
   locales:
     de: Deutsch
     en: English

--- a/config/locales/locale_picker.zh.yml
+++ b/config/locales/locale_picker.zh.yml
@@ -1,3 +1,4 @@
+---
 zh:
   locales:
     de: Deutsch

--- a/spec/features/locale_picker_spec.rb
+++ b/spec/features/locale_picker_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe 'Locale picker', type: :feature do
     expect(page).to have_text 'Historia'
     expect(page).to have_css 'li', text: 'English'
   end
+
+  it 'handles locales with country codes' do
+    visit root_url
+    
+    expect(page).to have_css '#language-dropdown-menu'
+    expect(page).to have_css 'li', text: 'English'
+    expect(page).to have_css 'li', text: 'Português braileiro'
+
+    expect(page).to have_text 'Welcome'
+    click_link 'Português braileiro'
+    expect(page).to have_text 'Bem-Vindo'
+  end
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'i18n/tasks'
+RSpec.describe 'I18n' do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:unused_keys) { i18n.unused_keys }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+    "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  it 'does not have unused keys' do
+    expect(unused_keys).to be_empty,
+    "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused'"
+  end
+
+  it 'files are normalized' do
+    non_normalized = i18n.non_normalized_paths
+    error_message = "The following files need to be normalized:\n" \
+                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                    'Please run `i18n-tasks normalize` to fix'
+    expect(non_normalized).to be_empty, error_message
+  end
+end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -27,7 +27,7 @@ class TestAppGenerator < Rails::Generators::Base
 
   def add_test_locales
     initializer 'test_configuration.rb' do
-      "Blacklight::LocalePicker::Engine.config.available_locales = [:en, :es]"
+      "Blacklight::LocalePicker::Engine.config.available_locales = ['en', 'es', 'pt-BR']"
     end
   end
 end


### PR DESCRIPTION
Pre-requisite #6 (I split this out from #6 to make review a little more digestible)
Closes #7 

This PR: 
- Adds an `aria-label on the dropdown` w/ the string "Language"
- Adds translations for "Language" to each locale 

When I was testing this out, I ran into issues with the test app generator and `pt-BR`. We had a similar problem with trying to pass around locales as symbols in Spotlight and opted to work mostly with strings over there. 

In this PR, I made the following updates: 
- Update the test app generator so that is uses strings instead of symbols
- Update README example 
- Adds a test for locales with country codes
- [ ] Submit a PR to ArcLight to update the test app generator there 
https://github.com/projectblacklight/arclight/blob/1ff1a586f360dda0f861b69fe4a215d87ff7063b/spec/test_app_templates/lib/generators/test_app_generator.rb#L30-L34