### PR TITLE
Remove incorrect menu aria role

### DIFF
--- a/app/views/shared/_locale_picker.html.erb
+++ b/app/views/shared/_locale_picker.html.erb
@@ -4,7 +4,7 @@
       <span><%= t("locales.#{I18n.locale}") %></span>
       <b class="caret"></b>
     </a>
-    <ul id="language-dropdown-menu" class="dropdown-menu" role="menu">
+    <ul id="language-dropdown-menu" class="dropdown-menu">
       <li role="presentation" class="divider"></li>
       <% available_locales.each do |locale| %>
         <li role="presentation" lang="<%= locale %>">


### PR DESCRIPTION
The "menu" aria role was not implemented correctly here (it was missing menuitems).

According to the following guidance, it seems that removing the role is the best move here, as the language picker is not a context menu or a re-creation of a desktop application navigation (Google Docs-style):

* https://adrianroselli.com/2017/10/dont-use-aria-menu-roles-for-site-nav.html
* https://webaim.org/blog/aria-cause-solution/
* https://www.levelaccess.com/challenges-mega-menus-standard-menus-make-accessible/
