### PR TITLE
Drop rails 6.0 as it is no longer supported

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
         ruby: ['3.0']
         include:
           - ruby: 2.7
-            rails_version: 6.0.6
+            rails_version: 6.1.7
           - ruby: 3.1
             rails_version: 7.0.4
     env:


### PR DESCRIPTION
See https://guides.rubyonrails.org/maintenance_policy.html