### PR TITLE
Test on released version of blacklight

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -12,7 +12,7 @@ class TestAppGenerator < Rails::Generators::Base
     if version
       gem 'blacklight', version
     else
-      gem 'blacklight', github: 'projectblacklight/blacklight'
+      gem 'blacklight' # latest version
     end
 
     Bundler.with_clean_env do


### PR DESCRIPTION
Because blacklight doesn't rollup the assets needed to support a sprockets build until it makes a gem. See 
https://github.com/projectblacklight/blacklight/commit/7287bd2060812e97483e7c85509507e80ef435ca